### PR TITLE
Add typing and documentation for preprocessing and models

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ python simple_deep_models.py
 python visualization_analysis.py
 ```
 
+### 5. 运行静态类型检查
+```bash
+mypy --ignore-missing-imports scripts/preprocessing/optimized_preprocessing.py \
+    scripts/models/simple_ml_models.py scripts/models/simple_deep_models.py
+```
+> 使用 ``--ignore-missing-imports`` 可以在未安装第三方库类型存根的环境下完成基本一致性检查。
+
 ## 主要结果
 
 ### 最佳模型性能


### PR DESCRIPTION
## Summary
- add detailed type annotations and docstrings to preprocessing, ML, and MLP training scripts
- describe side effects for data loading, sequence generation, and training entry points
- document mypy usage in the README for lightweight static analysis

## Testing
- mypy --ignore-missing-imports scripts/preprocessing/optimized_preprocessing.py scripts/models/simple_ml_models.py scripts/models/simple_deep_models.py


------
https://chatgpt.com/codex/tasks/task_e_68e61a279328832185a6c1ef8a62a6b0